### PR TITLE
Chore/portfolio polish round 2

### DIFF
--- a/client/components/AuthForm.test.js
+++ b/client/components/AuthForm.test.js
@@ -1,0 +1,125 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import AuthForm from './AuthForm';
+
+const setInputValue = (input, value) => {
+  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value',
+  ).set;
+  nativeInputValueSetter.call(input, value);
+  input.dispatchEvent(new window.Event('input', { bubbles: true }));
+};
+
+const renderForm = async (overrides = {}) => {
+  const notifications = [];
+  const logins = [];
+  const registrations = [];
+
+  const props = {
+    onLogin: async (...args) => logins.push(args),
+    onRegister: async (...args) => registrations.push(args),
+    showNotification: (message, isError) =>
+      notifications.push({ message, isError }),
+    ...overrides,
+  };
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<AuthForm {...props} />);
+  });
+
+  const cleanup = async () => {
+    await act(() => root.unmount());
+    document.body.removeChild(container);
+  };
+
+  return { container, notifications, logins, registrations, cleanup };
+};
+
+describe('<AuthForm />', () => {
+  it('renders login mode by default', async () => {
+    const { container, cleanup } = await renderForm();
+
+    assert.ok(container.textContent.includes('Sign in to your account'));
+    assert.ok(container.querySelector('#username'));
+    assert.ok(container.querySelector('#password'));
+    // Confirm password only exists in register mode
+    assert.strictEqual(container.querySelector('#confirmPassword'), null);
+
+    await cleanup();
+  });
+
+  it('switches to register mode', async () => {
+    const { container, cleanup } = await renderForm();
+
+    const toggle = container.querySelector('.auth-toggle-btn');
+    await act(async () => {
+      toggle.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    });
+
+    assert.ok(container.textContent.includes('Create a new account'));
+    assert.ok(container.querySelector('#confirmPassword'));
+
+    await cleanup();
+  });
+
+  it('submits login credentials', async () => {
+    const { container, logins, cleanup } = await renderForm();
+
+    await act(async () => {
+      setInputValue(container.querySelector('#username'), 'anna');
+      setInputValue(container.querySelector('#password'), 'password123');
+    });
+
+    const form = container.querySelector('form');
+    await act(async () => {
+      form.dispatchEvent(new window.Event('submit', { bubbles: true }));
+    });
+    // Flush the async submit handler's trailing state updates
+    await act(async () => {});
+
+    assert.deepStrictEqual(logins, [['anna', 'password123']]);
+
+    await cleanup();
+  });
+
+  it('warns when registering with mismatched passwords', async () => {
+    const { container, notifications, registrations, cleanup } =
+      await renderForm();
+
+    const toggle = container.querySelector('.auth-toggle-btn');
+    await act(async () => {
+      toggle.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await act(async () => {
+      setInputValue(container.querySelector('#username'), 'anna');
+      setInputValue(container.querySelector('#password'), 'password123');
+      setInputValue(
+        container.querySelector('#confirmPassword'),
+        'different123',
+      );
+    });
+
+    const form = container.querySelector('form');
+    await act(async () => {
+      form.dispatchEvent(new window.Event('submit', { bubbles: true }));
+    });
+
+    assert.strictEqual(registrations.length, 0);
+    assert.ok(
+      notifications.some(
+        (n) => n.isError && n.message === 'Passwords do not match',
+      ),
+    );
+
+    await cleanup();
+  });
+});

--- a/client/components/ConfirmDialog.jsx
+++ b/client/components/ConfirmDialog.jsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react';
+
+const ConfirmDialog = ({
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+}) => {
+  const confirmButtonRef = useRef(null);
+
+  useEffect(() => {
+    confirmButtonRef.current?.focus();
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onCancel();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
+  return (
+    <div className="confirm-overlay">
+      <div
+        className="confirm-dialog"
+        role="alertdialog"
+        aria-modal="true"
+        aria-describedby="confirm-dialog-message"
+      >
+        <p id="confirm-dialog-message" className="confirm-dialog-message">
+          {message}
+        </p>
+        <div className="confirm-dialog-actions">
+          <button
+            type="button"
+            className="confirm-dialog-btn confirm-dialog-cancel"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            ref={confirmButtonRef}
+            className="confirm-dialog-btn confirm-dialog-confirm"
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/client/components/ConfirmDialog.test.js
+++ b/client/components/ConfirmDialog.test.js
@@ -1,0 +1,84 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import ConfirmDialog from './ConfirmDialog';
+
+const renderDialog = async (props) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<ConfirmDialog message="Delete this contact?" {...props} />);
+  });
+
+  const cleanup = async () => {
+    await act(() => root.unmount());
+    document.body.removeChild(container);
+  };
+
+  return { container, cleanup };
+};
+
+describe('<ConfirmDialog />', () => {
+  it('renders the message and default labels', async () => {
+    const { container, cleanup } = await renderDialog({
+      onConfirm: () => {},
+      onCancel: () => {},
+    });
+
+    assert.ok(container.textContent.includes('Delete this contact?'));
+    assert.ok(container.textContent.includes('Confirm'));
+    assert.ok(container.textContent.includes('Cancel'));
+
+    const dialog = container.querySelector('[role="alertdialog"]');
+    assert.ok(dialog);
+    assert.strictEqual(dialog.getAttribute('aria-modal'), 'true');
+
+    await cleanup();
+  });
+
+  it('calls onConfirm when the confirm button is clicked', async () => {
+    let confirmed = false;
+    const { container, cleanup } = await renderDialog({
+      confirmLabel: 'Delete',
+      onConfirm: () => {
+        confirmed = true;
+      },
+      onCancel: () => {},
+    });
+
+    const confirmButton = container.querySelector('.confirm-dialog-confirm');
+    assert.strictEqual(confirmButton.textContent, 'Delete');
+
+    await act(async () => {
+      confirmButton.dispatchEvent(
+        new window.MouseEvent('click', { bubbles: true }),
+      );
+    });
+
+    assert.strictEqual(confirmed, true);
+    await cleanup();
+  });
+
+  it('calls onCancel when Escape is pressed', async () => {
+    let cancelled = false;
+    const { cleanup } = await renderDialog({
+      onConfirm: () => {},
+      onCancel: () => {
+        cancelled = true;
+      },
+    });
+
+    await act(async () => {
+      document.dispatchEvent(
+        new window.KeyboardEvent('keydown', { key: 'Escape' }),
+      );
+    });
+
+    assert.strictEqual(cancelled, true);
+    await cleanup();
+  });
+});

--- a/client/components/ErrorBoundary.jsx
+++ b/client/components/ErrorBoundary.jsx
@@ -1,0 +1,41 @@
+import { Component } from 'react';
+
+class ErrorBoundary extends Component {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('Unhandled UI error:', error, info);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="container">
+          <h1>Phonebook</h1>
+          <div className="error-boundary" role="alert">
+            <p>Something went wrong while rendering the app.</p>
+            <button
+              type="button"
+              className="actionbtn"
+              onClick={this.handleReload}
+            >
+              Reload page
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/client/components/Filter.test.js
+++ b/client/components/Filter.test.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import Filter from './Filter';
+
+describe('<Filter />', () => {
+  it('renders the input with the current value', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root;
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Filter newFilter="anna" onFilterChange={() => {}} />);
+    });
+
+    const input = container.querySelector('#filterInput');
+    assert.ok(input);
+    assert.strictEqual(input.value, 'anna');
+    assert.ok(container.textContent.includes('Showing results for "anna"'));
+
+    await act(() => root.unmount());
+    document.body.removeChild(container);
+  });
+
+  it('calls onFilterChange when typing', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root;
+    const calls = [];
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Filter newFilter="" onFilterChange={(value) => calls.push(value)} />,
+      );
+    });
+
+    const input = container.querySelector('#filterInput');
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value',
+    ).set;
+
+    await act(async () => {
+      nativeInputValueSetter.call(input, 'bob');
+      input.dispatchEvent(new window.Event('input', { bubbles: true }));
+    });
+
+    assert.deepStrictEqual(calls, ['bob']);
+
+    await act(() => root.unmount());
+    document.body.removeChild(container);
+  });
+
+  it('shows a clear button only when a filter is set', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root;
+    const calls = [];
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Filter newFilter="x" onFilterChange={(value) => calls.push(value)} />,
+      );
+    });
+
+    const clearButton = container.querySelector(
+      'button[aria-label="Clear search filter"]',
+    );
+    assert.ok(clearButton);
+
+    await act(async () => {
+      clearButton.dispatchEvent(
+        new window.MouseEvent('click', { bubbles: true }),
+      );
+    });
+
+    assert.deepStrictEqual(calls, ['']);
+
+    await act(() => root.unmount());
+    document.body.removeChild(container);
+  });
+});

--- a/client/components/NewPersonsForm.jsx
+++ b/client/components/NewPersonsForm.jsx
@@ -1,3 +1,4 @@
+import useConfirm from '../hooks/useConfirm';
 import {
   countryCodes,
   validateFirstName,
@@ -16,13 +17,16 @@ const NewPersonForm = ({
   handleNumberChange,
   handleCountryCodeChange,
 }) => {
-  const clearForm = () => {
+  const confirm = useConfirm();
+
+  const clearForm = async () => {
     const hasContent = newFirstName || newLastName || newNumber;
 
     if (hasContent) {
-      const confirmClear = window.confirm(
-        'Are you sure you want to clear all fields?',
-      );
+      const confirmClear = await confirm({
+        message: 'Are you sure you want to clear all fields?',
+        confirmLabel: 'Clear',
+      });
       if (!confirmClear) return;
     }
 

--- a/client/components/NewPersonsForm.test.js
+++ b/client/components/NewPersonsForm.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ConfirmProvider } from '../hooks/useConfirm';
 import NewPersonsForm from './NewPersonsForm';
 
 describe('<NewPersonsForm />', () => {
@@ -24,7 +25,11 @@ describe('<NewPersonsForm />', () => {
 
     await act(async () => {
       root = createRoot(container);
-      root.render(<NewPersonsForm {...mockProps} />);
+      root.render(
+        <ConfirmProvider>
+          <NewPersonsForm {...mockProps} />
+        </ConfirmProvider>,
+      );
     });
 
     assert.ok(container.textContent.includes('Add a new contact'));

--- a/client/components/UserHeader.jsx
+++ b/client/components/UserHeader.jsx
@@ -1,8 +1,14 @@
+import useConfirm from '../hooks/useConfirm';
+
 const UserHeader = ({ username, onLogout, onDeleteAccount }) => {
-  const handleDeleteAccount = () => {
-    const confirmed = window.confirm(
-      'Are you sure you want to delete your account? This will permanently remove all your contacts.',
-    );
+  const confirm = useConfirm();
+
+  const handleDeleteAccount = async () => {
+    const confirmed = await confirm({
+      message:
+        'Are you sure you want to delete your account? This will permanently remove all your contacts.',
+      confirmLabel: 'Delete account',
+    });
     if (confirmed) {
       onDeleteAccount();
     }

--- a/client/css/index.css
+++ b/client/css/index.css
@@ -911,3 +911,84 @@ h1 {
     width: 100%;
   }
 }
+
+/* ==========================================================================
+   Error boundary
+   ========================================================================== */
+
+.error-boundary {
+  text-align: center;
+  color: var(--text-gray);
+  padding: var(--spacing-2xl) 0;
+}
+
+.error-boundary p {
+  margin-bottom: var(--spacing-xl);
+}
+
+/* ==========================================================================
+   Confirm dialog
+   ========================================================================== */
+
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+  padding: var(--spacing-xl);
+  z-index: 1000;
+}
+
+.confirm-dialog {
+  background: var(--bg-white-solid);
+  border: 1px solid var(--border-gray);
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  padding: var(--spacing-2xl);
+  max-width: 420px;
+  width: 100%;
+}
+
+.confirm-dialog-message {
+  margin: 0 0 var(--spacing-xl);
+  color: var(--text-gray);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.confirm-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-md);
+}
+
+.confirm-dialog-btn {
+  padding: var(--spacing-sm) var(--spacing-xl);
+  border-radius: 8px;
+  border: 1px solid var(--border-gray);
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.confirm-dialog-cancel {
+  background: var(--bg-white);
+  color: var(--text-gray);
+}
+
+.confirm-dialog-confirm {
+  background: var(--primary-pink);
+  border-color: var(--primary-pink);
+  color: #fff;
+}
+
+@media (max-width: 768px) {
+  .confirm-dialog-actions {
+    flex-direction: column-reverse;
+  }
+
+  .confirm-dialog-btn {
+    width: 100%;
+  }
+}

--- a/client/hooks/useConfirm.jsx
+++ b/client/hooks/useConfirm.jsx
@@ -1,0 +1,59 @@
+import { createContext, useCallback, useContext, useState } from 'react';
+import ConfirmDialog from '../components/ConfirmDialog';
+
+const ConfirmContext = createContext(null);
+
+/**
+ * Provides a promise-based confirmation dialog. Wrap the app once and call the
+ * returned confirm() from any component or hook:
+ *
+ *   const confirm = useConfirm();
+ *   if (await confirm({ message: 'Delete?' })) { ... }
+ */
+export const ConfirmProvider = ({ children }) => {
+  const [dialog, setDialog] = useState(null);
+
+  const confirm = useCallback((options) => {
+    const config =
+      typeof options === 'string' ? { message: options } : options || {};
+
+    return new Promise((resolve) => {
+      setDialog({ ...config, resolve });
+    });
+  }, []);
+
+  const handleResolve = useCallback(
+    (result) => {
+      dialog?.resolve(result);
+      setDialog(null);
+    },
+    [dialog],
+  );
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {dialog && (
+        <ConfirmDialog
+          message={dialog.message}
+          confirmLabel={dialog.confirmLabel}
+          cancelLabel={dialog.cancelLabel}
+          onConfirm={() => handleResolve(true)}
+          onCancel={() => handleResolve(false)}
+        />
+      )}
+    </ConfirmContext.Provider>
+  );
+};
+
+const useConfirm = () => {
+  const confirm = useContext(ConfirmContext);
+
+  if (!confirm) {
+    throw new Error('useConfirm must be used within a ConfirmProvider');
+  }
+
+  return confirm;
+};
+
+export default useConfirm;

--- a/client/hooks/usePersons.js
+++ b/client/hooks/usePersons.js
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import apiService from '../services/api';
+import useConfirm from './useConfirm';
 
 const usePersons = (showNotification, user) => {
   const [persons, setPersons] = useState([]);
   const [loading, setLoading] = useState(true);
+  const confirm = useConfirm();
 
   useEffect(() => {
     if (!user) {
@@ -25,8 +27,7 @@ const usePersons = (showNotification, user) => {
       }
     };
     fetchPersons();
-    // Refetch only when the user changes; showNotification is intentionally omitted
-    // biome-ignore lint/correctness/useExhaustiveDependencies: stable notification handler, refetch keyed on user
+    // biome-ignore lint/correctness/useExhaustiveDependencies: refetch is intentionally keyed on user; showNotification is stable
   }, [user]);
 
   const addPerson = useCallback(
@@ -38,9 +39,10 @@ const usePersons = (showNotification, user) => {
       );
 
       if (existingPerson) {
-        const confirmUpdate = window.confirm(
-          `${firstName} ${lastName} is already added to phonebook, replace the old number with a new one?`,
-        );
+        const confirmUpdate = await confirm({
+          message: `${firstName} ${lastName} is already added to phonebook, replace the old number with a new one?`,
+          confirmLabel: 'Replace',
+        });
         if (!confirmUpdate) return;
 
         const response = await apiService.updatePerson(
@@ -57,7 +59,7 @@ const usePersons = (showNotification, user) => {
         showNotification(`Added ${firstName} ${lastName}`, false);
       }
     },
-    [persons, showNotification],
+    [persons, showNotification, confirm],
   );
 
   const removePerson = useCallback(
@@ -65,9 +67,10 @@ const usePersons = (showNotification, user) => {
       const person = persons.find((p) => p.id === id);
       if (!person) return;
 
-      const confirmDeletion = window.confirm(
-        `Delete ${person.firstName} ${person.lastName}?`,
-      );
+      const confirmDeletion = await confirm({
+        message: `Delete ${person.firstName} ${person.lastName}?`,
+        confirmLabel: 'Delete',
+      });
       if (!confirmDeletion) return;
 
       try {
@@ -84,7 +87,7 @@ const usePersons = (showNotification, user) => {
         );
       }
     },
-    [persons, showNotification],
+    [persons, showNotification, confirm],
   );
 
   return { persons, loading, addPerson, removePerson };

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -4,10 +4,16 @@ import ReactDOM from 'react-dom/client';
 import './css/index.css';
 
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
+import { ConfirmProvider } from './hooks/useConfirm';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <ConfirmProvider>
+        <App />
+      </ConfirmProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2022",
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
-    "baseUrl": "./",
     "checkJs": false
   },
   "exclude": ["node_modules", "build", "dist"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-phonebook-application",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "A modern phonebook application with user authentication, real-time validation, international phone number support, and comprehensive testing. Originally created for Full Stack Open 2023, modernized in 2026.",
   "main": "index.js",
   "scripts": {

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -98,12 +98,19 @@ authRouter.get('/me', requireAuth, async (request, response, next) => {
 // Delete account + all user's persons (cascade)
 authRouter.delete('/me', requireAuth, async (request, response, next) => {
   try {
-    await Person.deleteMany({ user: request.user.id });
+    const { deletedCount } = await Person.deleteMany({
+      user: request.user.id,
+    });
     const deletedUser = await User.findByIdAndDelete(request.user.id);
 
     if (!deletedUser) {
       return response.status(404).json({ error: 'User not found' });
     }
+
+    // Audit log for a destructive operation (no personal data, only ids/counts)
+    console.info(
+      `AUDIT account deleted: userId=${request.user.id} contactsRemoved=${deletedCount}`,
+    );
 
     response.status(204).end();
   } catch (error) {

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -137,6 +137,21 @@ const securityHeaders = (_req, res, next) => {
     'Strict-Transport-Security',
     'max-age=31536000; includeSubDomains',
   );
+  res.setHeader('Referrer-Policy', 'no-referrer');
+  res.setHeader('X-Permitted-Cross-Domain-Policies', 'none');
+  res.setHeader(
+    'Content-Security-Policy',
+    [
+      "default-src 'self'",
+      // Inline styles are needed for the bundled CSS and runtime style attributes
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data:",
+      "connect-src 'self'",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "frame-ancestors 'none'",
+    ].join('; '),
+  );
   next();
 };
 


### PR DESCRIPTION
## Summary

Second round of portfolio polish: replaces native `window.confirm()` with an accessible custom dialog, adds a React error boundary, hardens backend security headers, and significantly expands frontend test coverage. No behaviour regressions — 68 tests pass (54 backend, 14 frontend) and the full stack is verified end-to-end.

Version bumped `5.0.0 → 5.1.0` (backward-compatible features).

## What changed

**Frontend UX & resilience**
- **Confirm dialog** — new promise-based `ConfirmProvider`/`useConfirm` + `ConfirmDialog` component (`role="alertdialog"`, `aria-modal`, focus management, Escape to cancel). Replaces all four `window.confirm()` calls (clear form, replace contact, delete contact, delete account) with a consistent, accessible, on-brand modal.
- **Error boundary** — `ErrorBoundary` wraps the app with a recoverable fallback ("Reload page"), so a render error no longer blanks the whole UI.

**Backend security**
- Added `Content-Security-Policy`, `Referrer-Policy: no-referrer` and `X-Permitted-Cross-Domain-Policies: none` to the security-headers middleware (CSP allows `'self'` + inline styles for the bundled CSS).
- Audit log on account deletion: records user id and removed contact count — no personal data.

**Tests**
- Added tests for `AuthForm` (login/register/validation/submit), `Filter` (input, clear button) and `ConfirmDialog` (render, confirm, Escape).
- Wrapped the existing `NewPersonsForm` test in `ConfirmProvider`.
- Frontend test count: **4 → 14**.

## How to test

```bash
bun install
bun test                      # 54 backend + 14 frontend
bun run build                 # Vite production build
bunx biome ci .               # lint + format check (green)
bun run dev                   # try the confirm modal: clear form / delete contact / delete account
curl -D - http://localhost:5001/health   # verify CSP / Referrer-Policy headers
```

## Notes

- `ConfirmDialog` closes via Escape or the Cancel button. I deliberately omitted backdrop-click-to-close to avoid an interactive static element (keeps it accessible without extra handlers).
- Scoped out for now: `useAuth` hook tests need localStorage + API mocking, which is heavier and less stable under jsdom/Bun — `AuthForm` covers the auth UI logic instead. TypeScript migration and a Dockerfile remain as possible follow-ups.
