### PR TITLE
fix: persist auth session on refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ PORT=5001
 # MongoDB connection string used in development and production
 MONGODB_URI=mongodb://localhost:27017/phonebook
 
-# Separate database used when NODE_ENV=test (falls back to MONGODB_URI if unset)
+# Separate database used by backend tests. Do not point this at development data.
 TEST_MONGODB_URI=mongodb://localhost:27017/phonebook_test
 
 # Secret used to sign JWT tokens. Required in production; generate a long random value.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ PORT=5001
 ```
 
 `JWT_SECRET` is required in production; the server refuses to start without a secure value.
+`TEST_MONGODB_URI` must point to a separate test database because backend tests delete data.
 
 ### Development
 

--- a/client/hooks/useAuth.js
+++ b/client/hooks/useAuth.js
@@ -18,11 +18,18 @@ const useAuth = () => {
 
       try {
         const parsed = JSON.parse(stored);
+        if (!parsed?.token) {
+          throw new Error('Stored user is missing a token');
+        }
+
         apiService.setToken(parsed.token);
 
         // Validate token by calling /me
-        await apiService.getMe();
-        setUser(parsed);
+        const response = await apiService.getMe();
+        const userData = { ...response.data, token: parsed.token };
+
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(userData));
+        setUser(userData);
       } catch (_error) {
         // Token expired or invalid
         window.localStorage.removeItem(STORAGE_KEY);

--- a/client/hooks/useAuth.test.js
+++ b/client/hooks/useAuth.test.js
@@ -1,0 +1,137 @@
+import assert from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { act, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import apiService from '../services/api';
+import useAuth from './useAuth';
+
+const STORAGE_KEY = 'phonebook-user';
+const originalFetch = global.fetch;
+
+const waitFor = async (assertion) => {
+  let lastError;
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+
+  throw lastError;
+};
+
+const AuthProbe = ({ onState }) => {
+  const auth = useAuth();
+  const { loading, user } = auth;
+
+  useEffect(() => {
+    onState({ loading, user });
+  }, [loading, user, onState]);
+
+  return <span>{loading ? 'loading' : user?.username || 'signed-out'}</span>;
+};
+
+const renderProbe = async (onState = () => {}) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<AuthProbe onState={onState} />);
+  });
+
+  const cleanup = async () => {
+    await act(() => root.unmount());
+    document.body.removeChild(container);
+  };
+
+  return { container, cleanup };
+};
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  window.localStorage.clear();
+  apiService.clearToken();
+});
+
+describe('useAuth', () => {
+  it('refreshes stored sessions from the current user endpoint', async () => {
+    const calls = [];
+
+    global.fetch = async (url, options) => {
+      calls.push({ url, options });
+
+      return new Response(
+        JSON.stringify({ username: 'fresh-user', id: 'fresh-id' }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    };
+
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        username: 'stale-user',
+        id: 'stale-id',
+        token: 'stored-token',
+      }),
+    );
+
+    const { container, cleanup } = await renderProbe();
+
+    await waitFor(() => {
+      assert.strictEqual(container.textContent, 'fresh-user');
+    });
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].url, '/api/auth/me');
+    assert.strictEqual(
+      calls[0].options.headers.Authorization,
+      'Bearer stored-token',
+    );
+
+    const storedUser = JSON.parse(window.localStorage.getItem(STORAGE_KEY));
+    assert.deepStrictEqual(storedUser, {
+      username: 'fresh-user',
+      id: 'fresh-id',
+      token: 'stored-token',
+    });
+
+    await cleanup();
+  });
+
+  it('clears malformed stored sessions without calling the API', async () => {
+    const states = [];
+
+    global.fetch = async () => {
+      throw new Error('fetch should not be called');
+    };
+
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ username: 'stale-user' }),
+    );
+
+    const { container, cleanup } = await renderProbe((auth) => {
+      states.push({ loading: auth.loading, user: auth.user });
+    });
+
+    await waitFor(() => {
+      assert.strictEqual(container.textContent, 'signed-out');
+    });
+
+    assert.strictEqual(window.localStorage.getItem(STORAGE_KEY), null);
+    assert.strictEqual(states.at(-1).user, null);
+
+    await cleanup();
+  });
+});

--- a/client/hooks/usePersons.js
+++ b/client/hooks/usePersons.js
@@ -27,8 +27,7 @@ const usePersons = (showNotification, user) => {
       }
     };
     fetchPersons();
-    // biome-ignore lint/correctness/useExhaustiveDependencies: refetch is intentionally keyed on user; showNotification is stable
-  }, [user]);
+  }, [user, showNotification]);
 
   const addPerson = useCallback(
     async (personData) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-phonebook-application",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A modern phonebook application with user authentication, real-time validation, international phone number support, and comprehensive testing. Originally created for Full Stack Open 2023, modernized in 2026.",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "bun run test:frontend && bun run test:backend",
-    "test:frontend": "bun test --preload ./client/test-setup.js client/components/*.test.js",
+    "test:frontend": "bun test --preload ./client/test-setup.js client/components/*.test.js client/hooks/*.test.js",
     "test:backend": "NODE_ENV=test bun test --concurrency 1 server/tests/*.test.js",
     "test:watch": "NODE_ENV=test bun test --watch --concurrency 1 server/tests/*.test.js",
     "lint": "biome lint .",

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -8,11 +8,29 @@ const { requireAuth } = require('../middleware/auth');
 const SALT_ROUNDS = 10;
 const MIN_PASSWORD_LENGTH = 8;
 
+const normalizeUsername = (username) => username.trim().toLowerCase();
+
+const createAuthResponse = async (user) => {
+  const id = user._id.toString();
+  const token = await generateToken(id, user.username);
+
+  return {
+    token,
+    username: user.username,
+    id,
+  };
+};
+
 // Register
 authRouter.post('/register', async (request, response, next) => {
   const { username, password } = request.body;
 
-  if (typeof username !== 'string' || typeof password !== 'string') {
+  if (
+    typeof username !== 'string' ||
+    typeof password !== 'string' ||
+    !username.trim() ||
+    !password
+  ) {
     return response
       .status(400)
       .json({ error: 'Username and password are required' });
@@ -26,16 +44,13 @@ authRouter.post('/register', async (request, response, next) => {
 
   try {
     const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
-    const user = new User({ username, passwordHash });
+    const user = new User({
+      username: normalizeUsername(username),
+      passwordHash,
+    });
     const savedUser = await user.save();
 
-    const token = await generateToken(savedUser.id, savedUser.username);
-
-    response.status(201).json({
-      token,
-      username: savedUser.username,
-      id: savedUser.id,
-    });
+    response.status(201).json(await createAuthResponse(savedUser));
   } catch (error) {
     next(error);
   }
@@ -45,14 +60,19 @@ authRouter.post('/register', async (request, response, next) => {
 authRouter.post('/login', async (request, response, next) => {
   const { username, password } = request.body;
 
-  if (typeof username !== 'string' || typeof password !== 'string') {
+  if (
+    typeof username !== 'string' ||
+    typeof password !== 'string' ||
+    !username.trim() ||
+    !password
+  ) {
     return response
       .status(400)
       .json({ error: 'Username and password are required' });
   }
 
   try {
-    const user = await User.findOne({ username: username.toLowerCase() });
+    const user = await User.findOne({ username: normalizeUsername(username) });
 
     if (!user) {
       return response
@@ -68,13 +88,7 @@ authRouter.post('/login', async (request, response, next) => {
         .json({ error: 'Invalid username or password' });
     }
 
-    const token = await generateToken(user.id, user.username);
-
-    response.json({
-      token,
-      username: user.username,
-      id: user.id,
-    });
+    response.json(await createAuthResponse(user));
   } catch (error) {
     next(error);
   }

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -107,6 +107,25 @@ describe('Auth API', () => {
       assert.strictEqual(result.body.username, helper.testUser.username);
     });
 
+    it('accepts different casing and surrounding whitespace in username', async () => {
+      await helper.createTestUser({
+        username: 'caseuser',
+        password: helper.testUser.password,
+      });
+
+      const result = await api
+        .post('/api/auth/login')
+        .send({
+          username: '  CASEUSER  ',
+          password: helper.testUser.password,
+        })
+        .expect(200)
+        .expect('Content-Type', /application\/json/);
+
+      assert.ok(result.body.token);
+      assert.strictEqual(result.body.username, 'caseuser');
+    });
+
     it('returns 401 with wrong password', async () => {
       await helper.createTestUser();
 

--- a/server/tests/setup.js
+++ b/server/tests/setup.js
@@ -1,16 +1,21 @@
 const mongoose = require('mongoose');
 
+const testMongoUri = process.env.TEST_MONGODB_URI?.trim();
+const developmentMongoUri = process.env.MONGODB_URI?.trim();
+
+if (!testMongoUri) {
+  throw new Error('TEST_MONGODB_URI environment variable is required for tests');
+}
+
+if (developmentMongoUri && testMongoUri === developmentMongoUri) {
+  throw new Error(
+    'TEST_MONGODB_URI must point to a separate test database because backend tests delete data',
+  );
+}
+
 const connectDB = async () => {
-  const mongoUri = process.env.TEST_MONGODB_URI || process.env.MONGODB_URI;
-
-  if (!mongoUri) {
-    throw new Error(
-      'TEST_MONGODB_URI or MONGODB_URI environment variable is required for tests',
-    );
-  }
-
   if (mongoose.connection.readyState === 0) {
-    await mongoose.connect(mongoUri, {
+    await mongoose.connect(testMongoUri, {
       maxPoolSize: 10,
       serverSelectionTimeoutMS: 5000,
       socketTimeoutMS: 45000,


### PR DESCRIPTION
### Summary

Fix auth session persistence so refreshing the app no longer signs the user out when the stored token is valid.

### What changed

- Refresh auth state from `/api/auth/me` instead of trusting stale localStorage user data.
- Preserve the stored token while updating localStorage with the current user returned by the API.
- Normalize usernames consistently during register and login.
- Generate auth responses from the explicit Mongo `_id` string.
- Add frontend regression tests for restoring and clearing stored auth sessions.
- Add backend regression coverage for login with username casing/whitespace differences.
- Add a backend test safety guard so tests fail fast if `TEST_MONGODB_URI` points to the development database.
- Bump version from `5.1.0` to `5.1.1`.

### How to test

1. Run `bun run test:frontend`.
2. Run `bun run lint`.
3. Run `bun run build`.
4. Manually verify:
   - Create an account.
   - Add a contact.
   - Refresh the page.
   - Confirm the user stays signed in and contacts are still shown.
   - Sign out and sign back in with the same account.

### Notes

`bun run test:backend` now requires `TEST_MONGODB_URI` to point to a separate test database. This prevents backend tests from deleting development data by accident.