### PR TITLE
fix: stabilize ci checks

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -28,7 +28,6 @@ jobs:
     env:
       NODE_ENV: test
       TEST_MONGODB_URI: "${{ secrets.TEST_MONGODB_URI || 'mongodb://testuser:testpass@localhost:27017/test_phonebook?authSource=admin' }}"
-      MONGODB_URI: "${{ secrets.TEST_MONGODB_URI || 'mongodb://testuser:testpass@localhost:27017/test_phonebook?authSource=admin' }}"
 
     steps:
       - name: Checkout code
@@ -45,7 +44,6 @@ jobs:
       - name: Verify environment setup
         run: |
           echo "NODE_ENV: $NODE_ENV"
-          echo "MONGODB_URI is set: $([ -n "$MONGODB_URI" ] && echo "yes" || echo "no")"
           echo "TEST_MONGODB_URI is set: $([ -n "$TEST_MONGODB_URI" ] && echo "yes" || echo "no")"
 
       - name: Lint and format check

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noConsole": "off"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-phonebook-application",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "A modern phonebook application with user authentication, real-time validation, international phone number support, and comprehensive testing. Originally created for Full Stack Open 2023, modernized in 2026.",
   "main": "index.js",
   "scripts": {

--- a/server/tests/setup.js
+++ b/server/tests/setup.js
@@ -4,7 +4,9 @@ const testMongoUri = process.env.TEST_MONGODB_URI?.trim();
 const developmentMongoUri = process.env.MONGODB_URI?.trim();
 
 if (!testMongoUri) {
-  throw new Error('TEST_MONGODB_URI environment variable is required for tests');
+  throw new Error(
+    'TEST_MONGODB_URI environment variable is required for tests',
+  );
 }
 
 if (developmentMongoUri && testMongoUri === developmentMongoUri) {


### PR DESCRIPTION
### Summary

Fix CI failures caused by Biome formatting drift and conflicting test database environment variables.

### What changed

- Formatted `server/tests/setup.js` with Biome.
- Updated Biome config from deprecated `recommended` to `preset: "recommended"`.
- Removed `MONGODB_URI` from the CI test environment so backend tests use `TEST_MONGODB_URI` only.
- Bumped package version to `5.1.2`.

### How to test

1. `bunx biome ci .`
2. `bun run test:frontend`
3. `bun run build`