### PR TITLE
chore: polish fixes, middleware and hook unit tests, bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ dist
 .tern-port
 
 
-DS_Store
+.DS_Store
 **/.DS_Store
 
 build

--- a/client/css/index.css
+++ b/client/css/index.css
@@ -358,10 +358,6 @@ button:disabled:hover {
   color: var(--color-error);
 }
 
-.validation-message.success {
-  color: var(--color-success);
-}
-
 /* ───────────── Notifications ───────────── */
 .notification-alert {
   margin: 1rem 1.25rem 0;

--- a/client/hooks/useNotification.test.js
+++ b/client/hooks/useNotification.test.js
@@ -1,0 +1,134 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import useNotification from './useNotification';
+
+const NotificationProbe = ({ duration, apiRef }) => {
+  const notification = useNotification(duration);
+  apiRef.current = notification;
+
+  return <div>{notification.message}</div>;
+};
+
+const renderProbe = async (duration) => {
+  const apiRef = { current: null };
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root;
+
+  await act(async () => {
+    root = createRoot(container);
+    root.render(<NotificationProbe duration={duration} apiRef={apiRef} />);
+  });
+
+  const cleanup = async () => {
+    await act(() => root.unmount());
+    document.body.removeChild(container);
+  };
+
+  return { container, apiRef, cleanup };
+};
+
+const sleep = (ms) =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+
+describe('useNotification', () => {
+  it('shows a message and auto-clears it after the duration', async () => {
+    const { container, apiRef, cleanup } = await renderProbe(50);
+
+    await act(async () => {
+      apiRef.current.showNotification('Added Anna Smith');
+    });
+
+    assert.strictEqual(apiRef.current.message, 'Added Anna Smith');
+    assert.strictEqual(apiRef.current.isError, false);
+    assert.ok(container.textContent.includes('Added Anna Smith'));
+
+    await sleep(150);
+
+    assert.strictEqual(apiRef.current.message, null);
+    assert.strictEqual(apiRef.current.isError, false);
+
+    await cleanup();
+  });
+
+  it('flags error notifications', async () => {
+    const { apiRef, cleanup } = await renderProbe(50);
+
+    await act(async () => {
+      apiRef.current.showNotification('Something failed', true);
+    });
+
+    assert.strictEqual(apiRef.current.message, 'Something failed');
+    assert.strictEqual(apiRef.current.isError, true);
+
+    await cleanup();
+  });
+
+  it('replaces the message and restarts the timer on consecutive notifications', async () => {
+    const { apiRef, cleanup } = await renderProbe(500);
+
+    await act(async () => {
+      apiRef.current.showNotification('first', true);
+    });
+    await sleep(300);
+    await act(async () => {
+      apiRef.current.showNotification('second');
+    });
+
+    assert.strictEqual(apiRef.current.message, 'second');
+    assert.strictEqual(apiRef.current.isError, false);
+
+    // 600ms after the first call its timer would have fired, but it was
+    // cleared by the second call, so the second message is still visible
+    await sleep(300);
+    assert.strictEqual(apiRef.current.message, 'second');
+
+    // The second message clears after its own full duration
+    await sleep(300);
+    assert.strictEqual(apiRef.current.message, null);
+
+    await cleanup();
+  });
+
+  it('cancels the pending timer on unmount', async () => {
+    const originalSetTimeout = global.setTimeout;
+    const originalClearTimeout = global.clearTimeout;
+    const hookTimerIds = [];
+    const clearedIds = [];
+
+    // Track only the hook's timer via its distinctive duration, so timers
+    // set by React or the test itself don't cause false positives
+    global.setTimeout = (fn, delay, ...args) => {
+      const id = originalSetTimeout(fn, delay, ...args);
+      if (delay === 60000) {
+        hookTimerIds.push(id);
+      }
+      return id;
+    };
+    global.clearTimeout = (id) => {
+      clearedIds.push(id);
+      return originalClearTimeout(id);
+    };
+
+    try {
+      const { apiRef, cleanup } = await renderProbe(60000);
+
+      await act(async () => {
+        apiRef.current.showNotification('pending');
+      });
+
+      assert.strictEqual(hookTimerIds.length, 1);
+
+      await cleanup();
+
+      assert.ok(clearedIds.includes(hookTimerIds[0]));
+    } finally {
+      global.setTimeout = originalSetTimeout;
+      global.clearTimeout = originalClearTimeout;
+    }
+  });
+});

--- a/client/utils/errors.test.js
+++ b/client/utils/errors.test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { getErrorMessage } from './errors';
+
+describe('getErrorMessage', () => {
+  it('prefers the error field from the response body', () => {
+    const error = {
+      response: { data: { error: 'Username already taken', details: ['x'] } },
+      message: 'Request failed',
+    };
+
+    assert.strictEqual(getErrorMessage(error), 'Username already taken');
+  });
+
+  it('joins validation details when there is no error field', () => {
+    const error = {
+      response: {
+        data: { details: ['First name is required', 'Number is invalid'] },
+      },
+      message: 'Request failed',
+    };
+
+    assert.strictEqual(
+      getErrorMessage(error),
+      'First name is required, Number is invalid',
+    );
+  });
+
+  it('falls back to the error message without response data', () => {
+    assert.strictEqual(
+      getErrorMessage(new Error('Network down')),
+      'Network down',
+    );
+  });
+
+  it('ignores a response without a body', () => {
+    const error = { response: {}, message: 'Request timed out' };
+
+    assert.strictEqual(getErrorMessage(error), 'Request timed out');
+  });
+
+  it('uses the default fallback when nothing is available', () => {
+    assert.strictEqual(getErrorMessage({}), 'An unexpected error occurred');
+  });
+
+  it('uses a custom fallback when provided', () => {
+    assert.strictEqual(getErrorMessage({}, 'Sign in failed'), 'Sign in failed');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-phonebook-application",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A modern phonebook application with user authentication, real-time validation, international phone number support, and comprehensive testing. Originally created for Full Stack Open 2023, modernized in 2026.",
   "main": "index.js",
   "scripts": {

--- a/server/app.js
+++ b/server/app.js
@@ -10,7 +10,7 @@ const {
 const apiRouter = require('./controllers/apiController');
 const authRouter = require('./controllers/authController');
 const healthRouter = require('./controllers/healthController');
-const { inProduction, ALLOWED_ORIGINS } = require('./utils/config');
+const { inProduction, inTest, ALLOWED_ORIGINS } = require('./utils/config');
 const path = require('node:path');
 const app = express();
 
@@ -41,7 +41,10 @@ if (inProduction) {
   app.use(express.static(path.join(__dirname, '../build')));
 }
 
-app.use(httpLogger);
+// Skipped in tests to keep test output free of request log noise
+if (!inTest) {
+  app.use(httpLogger);
+}
 
 app.use('/api/auth', authRouter);
 app.use('/api', apiRouter);

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -83,7 +83,9 @@ const httpLogger = (request, response, next) => {
   next();
 };
 
-// Simple in-memory rate limiting middleware for API protection
+// Simple in-memory rate limiting middleware for API protection.
+// Counters are per-process, so limits apply per instance; a shared store
+// (e.g. Redis) would be needed when scaling beyond a single instance.
 const createRateLimiter = (windowMs = 15 * 60 * 1000, max = 100) => {
   const requests = new Map();
 

--- a/server/tests/middleware.test.js
+++ b/server/tests/middleware.test.js
@@ -1,6 +1,10 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { createRateLimiter } = require('../middleware/index');
+const { SignJWT } = require('jose');
+const { requireAuth } = require('../middleware/auth');
+const { createRateLimiter, errorHandler } = require('../middleware/index');
+const { generateToken } = require('../utils/auth');
+const { JWT_SECRET } = require('../utils/config');
 
 const createMockRes = () => {
   const res = { statusCode: null, body: null };
@@ -14,6 +18,8 @@ const createMockRes = () => {
   };
   return res;
 };
+
+const createMockReq = (authorization) => ({ get: () => authorization });
 
 describe('createRateLimiter', () => {
   it('allows requests under the limit', () => {
@@ -76,5 +82,96 @@ describe('createRateLimiter', () => {
     });
 
     assert.strictEqual(nextCalled, true);
+  });
+});
+
+describe('requireAuth', () => {
+  it('returns 401 when the authorization header is missing', async () => {
+    const res = createMockRes();
+    let nextCalled = false;
+
+    await requireAuth(createMockReq(undefined), res, () => {
+      nextCalled = true;
+    });
+
+    assert.strictEqual(nextCalled, false);
+    assert.strictEqual(res.statusCode, 401);
+    assert.strictEqual(res.body.error, 'Token missing');
+  });
+
+  it('returns 401 when the scheme is not bearer', async () => {
+    const res = createMockRes();
+    let nextCalled = false;
+
+    await requireAuth(createMockReq('Basic dXNlcjpwYXNz'), res, () => {
+      nextCalled = true;
+    });
+
+    assert.strictEqual(nextCalled, false);
+    assert.strictEqual(res.statusCode, 401);
+    assert.strictEqual(res.body.error, 'Token missing');
+  });
+
+  it('returns 401 for a malformed token', async () => {
+    const res = createMockRes();
+    let nextCalled = false;
+
+    await requireAuth(createMockReq('Bearer not-a-jwt'), res, () => {
+      nextCalled = true;
+    });
+
+    assert.strictEqual(nextCalled, false);
+    assert.strictEqual(res.statusCode, 401);
+    assert.strictEqual(res.body.error, 'Token invalid or expired');
+  });
+
+  it('returns 401 for an expired token', async () => {
+    const nowInSeconds = Math.floor(Date.now() / 1000);
+    const expiredToken = await new SignJWT({
+      id: 'user-id-123',
+      username: 'ada',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt(nowInSeconds - 7200)
+      .setExpirationTime(nowInSeconds - 3600)
+      .sign(new TextEncoder().encode(JWT_SECRET));
+
+    const res = createMockRes();
+    let nextCalled = false;
+
+    await requireAuth(createMockReq(`Bearer ${expiredToken}`), res, () => {
+      nextCalled = true;
+    });
+
+    assert.strictEqual(nextCalled, false);
+    assert.strictEqual(res.statusCode, 401);
+    assert.strictEqual(res.body.error, 'Token invalid or expired');
+  });
+
+  it('sets request.user and calls next for a valid token', async () => {
+    const token = await generateToken('user-id-123', 'ada');
+    const req = createMockReq(`Bearer ${token}`);
+    const res = createMockRes();
+    let nextCalled = false;
+
+    await requireAuth(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.strictEqual(nextCalled, true);
+    assert.strictEqual(res.statusCode, null);
+    assert.deepStrictEqual(req.user, { id: 'user-id-123', username: 'ada' });
+  });
+});
+
+describe('errorHandler', () => {
+  it('responds 500 without internal details for unexpected errors', () => {
+    const res = createMockRes();
+
+    errorHandler(new Error('database exploded'), {}, res, () => {});
+
+    assert.strictEqual(res.statusCode, 500);
+    // Outside development the body must not leak the error message
+    assert.deepStrictEqual(res.body, { error: 'Internal server error' });
   });
 });

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -9,6 +9,7 @@ const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
   : ['http://localhost:3000', 'http://127.0.0.1:3000'];
 
 const inProduction = process.env.NODE_ENV === 'production';
+const inTest = process.env.NODE_ENV === 'test';
 
 // JWT_SECRET must be provided explicitly in production. Outside production we
 // fall back to a clearly-unsafe development value and warn, so local setup and
@@ -32,6 +33,7 @@ if (inProduction) {
 
 module.exports = {
   inProduction,
+  inTest,
   MONGODB_URI,
   PORT,
   ALLOWED_ORIGINS,


### PR DESCRIPTION
# chore: portfolio polish round 3 — hygiene fixes and direct unit tests

## Summary

Final polish round based on a full portfolio-readiness audit (frontend, backend, repo meta). The audit found zero blockers; this PR clears the remaining minor findings: four hygiene fixes and direct unit tests for the last indirectly-tested paths.

## What changed

- **.gitignore**: fixed `DS_Store` → `.DS_Store` typo (line 109 already covered it via `**/.DS_Store`; cosmetic correctness)
- **client/css/index.css**: removed dead `.validation-message.success` rule — only the `error` variant is ever rendered
- **server/app.js + server/utils/config.js**: added `inTest` flag (mirrors `inProduction`) and skip `httpLogger` during tests, so test output is free of request-log noise
- **server/middleware/index.js**: documented that the in-memory rate limiter is per-process (shared store needed if scaling beyond one instance)
- **server/tests/middleware.test.js**: direct unit tests for `requireAuth` (missing header, non-bearer scheme, malformed token, expired token, valid token sets `request.user`) and for `errorHandler`'s generic 500 branch (asserts no internal details leak outside development)
- **client/hooks/useNotification.test.js** (new): auto-clear after duration, error flagging, timer restart on consecutive notifications, pending-timer cancellation on unmount
- **client/utils/errors.test.js** (new): all four `getErrorMessage` fallback branches plus custom fallback
- **package.json**: version 5.3.0 → 5.3.1

## How to test

- `bun run lint` — clean (also `bunx biome ci .`, same as CI)
- `bun run test:frontend` — 54/54 pass (was 44)
- `NODE_ENV=test bun test server/tests/middleware.test.js` — 10/10 pass without a database (was 4)
- Full backend suite runs in CI against the Mongo service; locally it requires a separate `TEST_MONGODB_URI`
- Logger gating verified end-to-end: `GET /live` logs a request line with `NODE_ENV=development` but not with `NODE_ENV=test`

## Notes

- No behavior changes outside tests: the only runtime-code change is the logger gate and a comment
- Audit items deliberately left as-is: CI `bun-version: 1.3.x` float, `/api/stats` placement in README, unused `format` field in `countryCodes` — judged acceptable/intentional
